### PR TITLE
feat(steps): Refactor step structure

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,10 +125,10 @@
 }
 
 #StepsCircle-Divider {
+  flex: 1;
   align-self: center;
   display: flex;
   height: 0px;
-  width: 27%;
   border: 1px solid #cbcbcb;
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,17 @@
 import React, { useMemo, useState } from 'react'
 import './App.css'
 import '@rainbow-me/rainbowkit/styles.css'
-import { Steps } from './types'
+import {
+  Steps,
+  Screens,
+  AppState,
+  TransferInUserActionNoKycScreens,
+  TransferInUserActionKycScreens,
+  TransferInNoUserActionKycScreens,
+  TransferInNoUserActionNoKycScreens,
+  TransferOutNoKycScreens,
+  TransferOutKycScreens,
+} from './types'
 import { publicProvider } from 'wagmi/providers/public'
 import { configureChains, createConfig, WagmiConfig } from 'wagmi'
 import { getDefaultWallets, RainbowKitProvider } from '@rainbow-me/rainbowkit'
@@ -20,7 +30,7 @@ import {
   TransferType,
 } from '@fiatconnect/fiatconnect-types'
 import { loadConfig } from './config'
-import { queryParamsSchema } from './schema'
+import { queryParamsSchema, QueryParams } from './schema'
 import { DoneSection } from './components/DoneSection'
 import { SendCrypto } from './components/SendCrypto'
 
@@ -33,6 +43,91 @@ function useQueryParams() {
 const DEFAULT_ERROR_TITLE = 'There was an error processing your request.'
 const DEFAULT_ERROR_MESSAGE =
   'This is typically due to a misconfiguration by your wallet provider.'
+
+// Gets current app "state" (i.e. progress) based off of query params etc.
+function useAppState(
+  queryParams: QueryParams | undefined,
+  finishedSignIn: boolean,
+  finishedUserActionDetails: boolean,
+  finishedSendCrypto: boolean,
+  kycApproved: boolean,
+  linkedAccount: ObfuscatedFiatAccountData | undefined,
+  transferResponse: TransferResponse | undefined,
+): AppState | undefined {
+  if (!queryParams) {
+    return undefined
+  }
+
+  const screens = getScreens(queryParams)
+
+  if (!finishedSignIn) {
+    return {
+      currentScreen: Screens.SignInScreen,
+      screens,
+    }
+  }
+  if (queryParams.kycSchema && !kycApproved) {
+    return {
+      currentScreen: Screens.KYCScreen,
+      screens,
+    }
+  }
+  if (!linkedAccount) {
+    return {
+      currentScreen: Screens.PaymentInfoScreen,
+      screens,
+    }
+  }
+  if (!transferResponse) {
+    return {
+      currentScreen: Screens.ReviewScreen,
+      screens,
+    }
+  }
+  if (queryParams.userActionDetailsSchema && !finishedUserActionDetails) {
+    return {
+      currentScreen: Screens.UserActionDetailsScreen,
+      screens,
+    }
+  }
+  if (
+    queryParams.transferType === TransferType.TransferOut &&
+    !finishedSendCrypto
+  ) {
+    return {
+      currentScreen: Screens.SendCryptoScreen,
+      screens,
+    }
+  }
+  return {
+    currentScreen: Screens.DoneScreen,
+    screens,
+  }
+}
+
+function getScreens(queryParams: QueryParams): Array<Screens> {
+  if (queryParams.transferType === TransferType.TransferIn) {
+    if (queryParams.kycSchema) {
+      if (queryParams.userActionDetailsSchema) {
+        return TransferInUserActionKycScreens
+      } else {
+        return TransferInNoUserActionKycScreens
+      }
+    } else {
+      if (queryParams.userActionDetailsSchema) {
+        return TransferInUserActionNoKycScreens
+      } else {
+        return TransferInNoUserActionNoKycScreens
+      }
+    }
+  } else {
+    if (queryParams.kycSchema) {
+      return TransferOutKycScreens
+    } else {
+      return TransferOutNoKycScreens
+    }
+  }
+}
 
 function App() {
   const queryParamsResults = useQueryParams()
@@ -50,6 +145,22 @@ function App() {
   const [transferResponse, setTransferResponse] = useState<
     TransferResponse | undefined
   >(undefined)
+
+  const [finishedSignIn, setFinishedSignIn] = useState(false)
+  const [finishedUserActionDetails, setFinishedUserActionDetails] =
+    useState(false)
+  const [finishedSendCrypto, setFinishedSendCrypto] = useState(false)
+  const [kycApproved, setKycApproved] = useState(false)
+
+  const appState = useAppState(
+    queryParamsResults.success ? queryParamsResults.data : undefined,
+    finishedSignIn,
+    finishedUserActionDetails,
+    finishedSendCrypto,
+    kycApproved,
+    linkedAccount,
+    transferResponse,
+  )
 
   const config = loadConfig()
   const { chains, publicClient } = useMemo(
@@ -77,80 +188,75 @@ function App() {
 
   const getSection = () => {
     // TODO: should never happen
-    if (!queryParamsResults.success) {
+    if (!queryParamsResults.success || !appState) {
       return
     }
-    if (step === Steps.One) {
-      return (
-        <SignInScreen
-          onError={onError}
-          onNext={setStep}
-          params={queryParamsResults.data}
-          setLinkedAccount={setLinkedAccount}
-        />
-      )
-    }
-    if (step === Steps.Two) {
-      return (
-        <PaymentInfoScreen
-          onError={onError}
-          onNext={setStep}
-          params={queryParamsResults.data}
-          setLinkedAccount={setLinkedAccount}
-        />
-      )
-    }
-    if (step === Steps.Three && linkedAccount) {
-      return (
-        <ReviewScreen
-          onError={onError}
-          onNext={setStep}
-          params={queryParamsResults.data}
-          linkedAccount={linkedAccount}
-          setTransferResponse={setTransferResponse}
-        />
-      )
-    }
-
-    if (
-      step === Steps.Four &&
-      transferResponse &&
-      'userActionDetails' in transferResponse &&
-      transferResponse.userActionDetails &&
-      queryParamsResults.data.transferType === TransferType.TransferIn
-    ) {
-      return (
-        <UserActionDetails
-          onNext={setStep}
-          userActionDetails={transferResponse.userActionDetails}
-          fiatAmount={queryParamsResults.data.fiatAmount}
-          fiatType={queryParamsResults.data.fiatType}
-          providerId={queryParamsResults.data.providerId}
-        />
-      )
-    }
-
-    if (
-      step === Steps.Four &&
-      transferResponse &&
-      queryParamsResults.data.transferType === TransferType.TransferOut
-    ) {
-      return (
-        <SendCrypto
-          onNext={setStep}
-          onError={onError}
-          transferAddress={transferResponse.transferAddress}
-          cryptoAmount={queryParamsResults.data.cryptoAmount}
-          cryptoType={queryParamsResults.data.cryptoType}
-          providerId={queryParamsResults.data.providerId}
-        />
-      )
-    }
-
-    if (step === Steps.Five) {
-      // TODO: Actually figure this out, and have sensible defaults like we do in the wallet
-      const settlementTime = '1 - 3 days'
-      return <DoneSection settlementTime={settlementTime} />
+    switch (appState.currentScreen) {
+      case Screens.SignInScreen: {
+        return (
+          <SignInScreen
+            onError={onError}
+            onNext={() => setFinishedSignIn(true)}
+            params={queryParamsResults.data}
+            setLinkedAccount={setLinkedAccount}
+          />
+        )
+      }
+      case Screens.PaymentInfoScreen: {
+        return (
+          <PaymentInfoScreen
+            onError={onError}
+            params={queryParamsResults.data}
+            setLinkedAccount={setLinkedAccount}
+          />
+        )
+      }
+      case Screens.ReviewScreen: {
+        if (!linkedAccount) return
+        return (
+          <ReviewScreen
+            onError={onError}
+            params={queryParamsResults.data}
+            linkedAccount={linkedAccount}
+            setTransferResponse={setTransferResponse}
+          />
+        )
+      }
+      case Screens.UserActionDetailsScreen: {
+        if (
+          !transferResponse ||
+          !('userActionDetails' in transferResponse) ||
+          !transferResponse.userActionDetails
+        )
+          return
+        return (
+          <UserActionDetails
+            onNext={() => setFinishedUserActionDetails(true)}
+            userActionDetails={transferResponse.userActionDetails}
+            fiatAmount={queryParamsResults.data.fiatAmount}
+            fiatType={queryParamsResults.data.fiatType}
+            providerId={queryParamsResults.data.providerId}
+          />
+        )
+      }
+      case Screens.SendCryptoScreen: {
+        if (!transferResponse) return
+        return (
+          <SendCrypto
+            onNext={() => setFinishedSendCrypto(true)}
+            onError={onError}
+            transferAddress={transferResponse.transferAddress}
+            cryptoAmount={queryParamsResults.data.cryptoAmount}
+            cryptoType={queryParamsResults.data.cryptoType}
+            providerId={queryParamsResults.data.providerId}
+          />
+        )
+      }
+      case Screens.DoneScreen: {
+        // TODO: Actually figure this out, and have sensible defaults like we do in the wallet
+        const settlementTime = '1 - 3 days'
+        return <DoneSection settlementTime={settlementTime} />
+      }
     }
   }
 
@@ -160,7 +266,7 @@ function App() {
         <div className="App">
           <header className="App-header">
             <div className="Container">
-              {queryParamsResults.success && !showError ? (
+              {queryParamsResults.success && appState && !showError ? (
                 <div className="SectionContainer">
                   <div className="ProviderTitle">
                     {
@@ -169,7 +275,7 @@ function App() {
                       ]
                     }
                   </div>
-                  <StepsHeader step={step} />
+                  <StepsHeader appState={appState} />
                   {getSection()}
                 </div>
               ) : (
@@ -183,7 +289,7 @@ function App() {
                           ]
                         }
                       </div>
-                      <StepsHeader step={step} />
+                      <StepsHeader appState={appState} />
                     </div>
                   )}
                   <ErrorSection title={errorTitle} message={errorMessage} />

--- a/src/components/PaymentInfoScreen.tsx
+++ b/src/components/PaymentInfoScreen.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { Steps } from '../types'
 import { fiatAccountSchemaToPaymentMethod } from '../constants'
 import {
   FiatAccountSchema,
@@ -18,14 +17,12 @@ import { QueryParams } from '../schema'
 
 interface Props {
   onError: (title: string, message: string) => void
-  onNext: (step: Steps) => void
   setLinkedAccount: (fiatAccount: ObfuscatedFiatAccountData) => void
   params: QueryParams
 }
 
 export function PaymentInfoScreen({
   onError,
-  onNext,
   setLinkedAccount,
   params,
 }: Props) {
@@ -71,7 +68,6 @@ export function PaymentInfoScreen({
           )
           if (linkedAccount) {
             setLinkedAccount(linkedAccount)
-            onNext(Steps.Three)
           } else {
             onError(errorTitle, errorMessage)
           }

--- a/src/components/ReviewScreen.tsx
+++ b/src/components/ReviewScreen.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react'
-import { Steps } from '../types'
 import { fiatAccountSchemaToPaymentMethod } from '../constants'
 import {
   TransferType,
@@ -14,7 +13,6 @@ import { QueryParams } from '../schema'
 
 interface Props {
   onError: (title: string, message: string) => void
-  onNext: (step: Steps) => void
   linkedAccount: ObfuscatedFiatAccountData
   setTransferResponse: (transferResponse: TransferResponse) => void
   params: QueryParams
@@ -22,7 +20,6 @@ interface Props {
 
 export function ReviewScreen({
   onError,
-  onNext,
   linkedAccount,
   setTransferResponse,
   params,
@@ -85,7 +82,6 @@ export function ReviewScreen({
     const transferResponseData =
       (await transferResponse.json()) as TransferResponse
     setTransferResponse(transferResponseData)
-    onNext(Steps.Four)
   }
 
   return (

--- a/src/components/SendCrypto.tsx
+++ b/src/components/SendCrypto.tsx
@@ -19,7 +19,7 @@ interface Props {
   cryptoAmount: string
   transferAddress: string
   providerId: ProviderIds
-  onNext: (step: Steps) => void
+  onNext: () => void
   onError: (title: string, message: string) => void
 }
 
@@ -128,7 +128,7 @@ export function SendCrypto({
 
   useEffect(() => {
     if (isSuccess) {
-      onNext(Steps.Five)
+      onNext()
     }
     if (isError) {
       onError(

--- a/src/components/StepsHeader.tsx
+++ b/src/components/StepsHeader.tsx
@@ -1,42 +1,47 @@
-import { Steps } from '../types'
-import { TransferType } from '@fiatconnect/fiatconnect-types'
+import { AppState, TransferInUserActionNoKycScreens, Screens } from '../types'
+
+const SCREEN_NAME_MAP = {
+  [Screens.SignInScreen]: 'Sign In',
+  [Screens.PaymentInfoScreen]: 'Payment Info',
+  [Screens.KYCScreen]: 'KYC',
+  [Screens.ReviewScreen]: 'Review',
+  [Screens.UserActionDetailsScreen]: 'Pay',
+  [Screens.SendCryptoScreen]: 'Pay',
+  [Screens.DoneScreen]: 'Done', // This will never be shown
+}
 
 interface Props {
-  step: Steps
-  transferType?: TransferType
+  appState?: AppState
 }
 
-const MAX_STEPS = 4
+const DEFAULT_SCREENS = TransferInUserActionNoKycScreens
+const DEFAULT_CURRENT_SCREEN = Screens.SignInScreen
 
-const STEP_TO_TITLE: Record<number, string> = {
-  1: 'Sign In',
-  2: 'Payment Info',
-  3: 'Review',
-  4: 'Pay',
-}
+export function StepsHeader({ appState }: Props) {
+  const screens = appState ? appState.screens : DEFAULT_SCREENS
+  const currentScreen = appState
+    ? appState.currentScreen
+    : DEFAULT_CURRENT_SCREEN
 
-export function StepsHeader({
-  step,
-  transferType = TransferType.TransferIn,
-}: Props) {
-  // TODO M2: Update this to take into account transfers out
-
+  const currentScreenStep = screens.indexOf(currentScreen)
   const makeSections = () => {
     const sections = []
-    for (let curStep = 1; curStep <= MAX_STEPS; curStep++) {
+    for (let curStep = 0; curStep < screens.length; curStep++) {
+      const curStepScreen = screens[curStep]
+
       const id =
-        step === curStep
+        curStepScreen === currentScreen
           ? 'StepsCircle-Current'
-          : step > curStep
+          : currentScreenStep > curStep || currentScreen === Screens.DoneScreen
           ? 'StepsCircle-Complete'
           : 'StepsCircle-Inactive'
       sections.push(
         <div key={`StepsCircle-${curStep}`} id={id}>
-          <div>{curStep}</div>
-          <div id="StepsHeader-Title">{STEP_TO_TITLE[curStep]}</div>
+          <div>{curStep + 1}</div>
+          <div id="StepsHeader-Title">{SCREEN_NAME_MAP[curStepScreen]}</div>
         </div>,
       )
-      if (curStep !== MAX_STEPS) {
+      if (curStep !== screens.length - 1) {
         sections.push(
           <div
             id="StepsCircle-Divider"

--- a/src/components/UserActionDetails.tsx
+++ b/src/components/UserActionDetails.tsx
@@ -20,7 +20,7 @@ interface Props {
   providerId: ProviderIds
   fiatAmount: string
   fiatType: FiatType
-  onNext: (step: Steps) => void
+  onNext: () => void
 }
 
 const BodyCard = styled.div`
@@ -125,10 +125,7 @@ export function UserActionDetails({
         below.
       </SectionSubtitle>
       {body}
-      <Button
-        onClick={() => onNext(Steps.Five)}
-        style={{ width: '100%', marginTop: '10px' }}
-      >
+      <Button onClick={onNext} style={{ width: '100%', marginTop: '10px' }}>
         Done
       </Button>
     </ContentContainer>

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,3 +28,67 @@ export interface FiatAccountFieldMetadata {
 export interface KycFieldMetadata extends FiatAccountFieldMetadata {
   group?: string // e.g. dateOfBirth, address
 }
+
+export enum Screens {
+  SignInScreen = 'SignInScreen',
+  PaymentInfoScreen = 'PaymentInfoScreen',
+  KYCScreen = 'KYCScreen',
+  ReviewScreen = 'ReviewScreen',
+  UserActionDetailsScreen = 'UserActionDetailsScreen',
+  SendCryptoScreen = 'SendCryptoScreen',
+  DoneScreen = 'DoneScreen',
+}
+
+export interface AppState {
+  currentScreen: Screens
+  screens: Array<Screens>
+}
+
+// Note that all flows end in Screens.DoneScreen, however this
+// is omitted from the screen lists since we do not want to
+// display a "Step" number in the flow UI -- kind of a hack.
+
+// Transfer in screen lists
+export const TransferInUserActionNoKycScreens = [
+  Screens.SignInScreen,
+  Screens.PaymentInfoScreen,
+  Screens.ReviewScreen,
+  Screens.UserActionDetailsScreen,
+]
+
+export const TransferInUserActionKycScreens = [
+  Screens.SignInScreen,
+  Screens.KYCScreen,
+  Screens.PaymentInfoScreen,
+  Screens.ReviewScreen,
+  Screens.UserActionDetailsScreen,
+]
+
+export const TransferInNoUserActionKycScreens = [
+  Screens.SignInScreen,
+  Screens.KYCScreen,
+  Screens.PaymentInfoScreen,
+  Screens.ReviewScreen,
+]
+
+export const TransferInNoUserActionNoKycScreens = [
+  Screens.SignInScreen,
+  Screens.PaymentInfoScreen,
+  Screens.ReviewScreen,
+]
+
+// Transfer out screen lists
+export const TransferOutNoKycScreens = [
+  Screens.SignInScreen,
+  Screens.PaymentInfoScreen,
+  Screens.ReviewScreen,
+  Screens.SendCryptoScreen,
+]
+
+export const TransferOutKycScreens = [
+  Screens.SignInScreen,
+  Screens.KYCScreen,
+  Screens.PaymentInfoScreen,
+  Screens.ReviewScreen,
+  Screens.SendCryptoScreen,
+]


### PR DESCRIPTION
A sorely needed change - this refactors how navigation is done between screens and how steps are displayed in the UI flow. Basically we just have a function in `App.tsx` that takes in a bunch of state and returns an ordered list of all screens that the user should see, as well as the screen that they should currently be on. This required adding a few new pieces of state (i.e., "done" flags) that are set from within individual screens; without these pieces of state, `App.tsx` wouldn't know when certain screens have already been completed.

One benefit of this change is that we can easily show any number of steps to the user, it's not hardcoded to a specific number. See pics below.

![2024-01-21-184334_1076x1414_scrot](https://github.com/fiatconnect/fiatconnect-widget/assets/569401/68da8b90-9e42-4ef2-aa9a-cc7359c4735d)
![2024-01-21-184323_1066x1413_scrot](https://github.com/fiatconnect/fiatconnect-widget/assets/569401/adf00a18-f473-4739-9ccf-f920f2ed6d03)
![2024-01-21-184312_1152x1433_scrot](https://github.com/fiatconnect/fiatconnect-widget/assets/569401/d71e96c9-898a-45eb-9f20-16fcbfb72f8e)


This isn't the prettiest thing ever, but I think it's an improvement. (shockingly, this worked perfectly first try without needing any debugging!)