### PR TITLE
chore: show error screen if simulate contract fails

### DIFF
--- a/src/components/SendCrypto.tsx
+++ b/src/components/SendCrypto.tsx
@@ -133,8 +133,8 @@ export function SendCrypto({
   useEffect(() => {
     if (prepareContractWriteStatus === 'error') {
       onError(
-        'There was an error preparing your payment.',
-        `There was an issue while preparing your payment to ${providerIdToProviderName[providerId]}`,
+        'There was an error preparing your transaction.',
+        `This may occur if you have less than ${cryptoAmount} ${cryptoType} in your wallet.`,
       )
     }
   }, [prepareContractWriteStatus])

--- a/src/components/SendCrypto.tsx
+++ b/src/components/SendCrypto.tsx
@@ -102,28 +102,33 @@ export function SendCrypto({
   const appConfig = loadConfig()
   const tokenAddress =
     cryptoTypeToAddress[appConfig.fiatConnectNetwork][cryptoType]!
-  const { config, status: prepareContractWriteStatus } = usePrepareContractWrite({
-    address: getAddress(tokenAddress),
-    abi: [
-      {
-        constant: false,
-        inputs: [
-          { name: '_to', type: 'address' },
-          { name: '_value', type: 'uint256' },
-        ],
-        name: 'transfer',
-        outputs: [{ name: 'success', type: 'bool' }],
-        stateMutability: 'nonpayable',
-        type: 'function',
-      },
-    ],
-    functionName: 'transfer',
-    args: [getAddress(transferAddress), parseEther(cryptoAmount)],
-  })
+  const { config, status: prepareContractWriteStatus } =
+    usePrepareContractWrite({
+      address: getAddress(tokenAddress),
+      abi: [
+        {
+          constant: false,
+          inputs: [
+            { name: '_to', type: 'address' },
+            { name: '_value', type: 'uint256' },
+          ],
+          name: 'transfer',
+          outputs: [{ name: 'success', type: 'bool' }],
+          stateMutability: 'nonpayable',
+          type: 'function',
+        },
+      ],
+      functionName: 'transfer',
+      args: [getAddress(transferAddress), parseEther(cryptoAmount)],
+    })
   const { isLoading, isSuccess, write, isError } = useContractWrite(config)
   useEffect(() => {
     // eslint-disable-next-line no-console
-    console.log(`config: ${JSON.stringify(config)}, config.result: ${config.result}, isSuccess: ${isSuccess}, isError: ${isError}, isLoading: ${isLoading}`)
+    console.log(
+      `config: ${JSON.stringify(config)}, config.result: ${
+        config.result
+      }, isSuccess: ${isSuccess}, isError: ${isError}, isLoading: ${isLoading}`,
+    )
   }, [config, isSuccess, isError])
 
   const onClick = () => {

--- a/src/components/SendCrypto.tsx
+++ b/src/components/SendCrypto.tsx
@@ -122,14 +122,6 @@ export function SendCrypto({
       args: [getAddress(transferAddress), parseEther(cryptoAmount)],
     })
   const { isLoading, isSuccess, write, isError } = useContractWrite(config)
-  useEffect(() => {
-    // eslint-disable-next-line no-console
-    console.log(
-      `config: ${JSON.stringify(config)}, config.result: ${
-        config.result
-      }, isSuccess: ${isSuccess}, isError: ${isError}, isLoading: ${isLoading}`,
-    )
-  }, [config, isSuccess, isError])
 
   const onClick = () => {
     write?.()

--- a/src/components/SendCrypto.tsx
+++ b/src/components/SendCrypto.tsx
@@ -134,7 +134,7 @@ export function SendCrypto({
     if (prepareContractWriteStatus === 'error') {
       onError(
         'There was an error preparing your transaction.',
-        `This may occur if you have less than ${cryptoAmount} ${cryptoType} in your wallet.`,
+        `This may occur if you have less ${cryptoType} in your wallet than you are trying to send (${cryptoAmount}).`,
       )
     }
   }, [prepareContractWriteStatus])


### PR DESCRIPTION
Michael reported a bug where if the user lacks the crypto to complete a transfer out, we still show a normal SendCrypto screen for them, but the button to send does nothing.

This adds the following error state for that scenario:
<img width="505" alt="Screenshot 2024-02-19 at 11 22 25 PM" src="https://github.com/fiatconnect/fiatconnect-widget/assets/7979215/adcf2410-e34a-49f8-b720-c8981b910ae1">
