### PR TITLE
feat: kyc allowed values

### DIFF
--- a/scripts/generateWidgetUrl.ts
+++ b/scripts/generateWidgetUrl.ts
@@ -1,7 +1,11 @@
 /* eslint-disable no-console */
 import yargs from 'yargs'
 import { ProviderIds } from '../src/types'
-import {CryptoType, FiatType, quoteResponseSchema} from '@fiatconnect/fiatconnect-types'
+import {
+  CryptoType,
+  FiatType,
+  quoteResponseSchema,
+} from '@fiatconnect/fiatconnect-types'
 
 function loadConfig() {
   return yargs
@@ -35,7 +39,7 @@ function loadConfig() {
       cryptoAmount: {
         type: 'string',
         description: 'Amount of crypto to get a quote for',
-        default: '2',
+        default: '1.01',
       },
       cryptoType: {
         description: 'Type of crypto to get a quote for',
@@ -109,7 +113,9 @@ export async function generateWidgetUrl() {
       widgetUrl += `&kycAllowedValues=${JSON.stringify(kycAllowedValues)}`
     }
   }
-  const fiatAccountType = Object.keys(fiatAccountJson)[0] as keyof typeof fiatAccountJson
+  const fiatAccountType = Object.keys(
+    fiatAccountJson,
+  )[0] as keyof typeof fiatAccountJson
   if (!fiatAccountType) {
     throw new Error('fiat account type not found in quote response')
   }
@@ -125,9 +131,15 @@ export async function generateWidgetUrl() {
   if (userActionType) {
     widgetUrl += `&userActionDetailsSchema=${userActionType}`
   }
-  const fiatAccountAllowedValues = fiatAccountJson[fiatAccountType]?.fiatAccountSchemas[0].allowedValues
-  if (fiatAccountAllowedValues && Object.keys(fiatAccountAllowedValues).length > 0) {
-    widgetUrl += `&fiatAccountAllowedValues=${JSON.stringify(fiatAccountAllowedValues)}`
+  const fiatAccountAllowedValues =
+    fiatAccountJson[fiatAccountType]?.fiatAccountSchemas[0].allowedValues
+  if (
+    fiatAccountAllowedValues &&
+    Object.keys(fiatAccountAllowedValues).length > 0
+  ) {
+    widgetUrl += `&fiatAccountAllowedValues=${JSON.stringify(
+      fiatAccountAllowedValues,
+    )}`
   }
   console.log(widgetUrl)
 }

--- a/scripts/generateWidgetUrl.ts
+++ b/scripts/generateWidgetUrl.ts
@@ -105,7 +105,7 @@ export async function generateWidgetUrl() {
     const kycSchema = kycSchemas[0].kycSchema
     widgetUrl += `&kycSchema=${kycSchema}`
     const kycAllowedValues = kycSchemas[0].allowedValues
-    if (kycAllowedValues) {
+    if (kycAllowedValues && Object.keys(kycAllowedValues).length > 0) {
       widgetUrl += `&kycAllowedValues=${JSON.stringify(kycAllowedValues)}`
     }
   }
@@ -126,7 +126,7 @@ export async function generateWidgetUrl() {
     widgetUrl += `&userActionDetailsSchema=${userActionType}`
   }
   const fiatAccountAllowedValues = fiatAccountJson[fiatAccountType]?.fiatAccountSchemas[0].allowedValues
-  if (fiatAccountAllowedValues) {
+  if (fiatAccountAllowedValues && Object.keys(fiatAccountAllowedValues).length > 0) {
     widgetUrl += `&fiatAccountAllowedValues=${JSON.stringify(fiatAccountAllowedValues)}`
   }
   console.log(widgetUrl)

--- a/scripts/generateWidgetUrl.ts
+++ b/scripts/generateWidgetUrl.ts
@@ -39,7 +39,7 @@ function loadConfig() {
       cryptoAmount: {
         type: 'string',
         description: 'Amount of crypto to get a quote for',
-        default: '1.01',
+        default: '2',
       },
       cryptoType: {
         description: 'Type of crypto to get a quote for',

--- a/scripts/generateWidgetUrl.ts
+++ b/scripts/generateWidgetUrl.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import yargs from 'yargs'
 import { ProviderIds } from '../src/types'
-import { CryptoType, FiatType } from '@fiatconnect/fiatconnect-types'
+import {CryptoType, FiatType, quoteResponseSchema} from '@fiatconnect/fiatconnect-types'
 
 function loadConfig() {
   return yargs
@@ -80,10 +80,10 @@ export async function generateWidgetUrl() {
       }),
     },
   )
-  const quoteJson = await response.json()
   if (!response.ok) {
-    throw new Error(`quote response error json: ${JSON.stringify(quoteJson)}`)
+    throw new Error(`quote response error status: ${response.status}`)
   }
+  const quoteJson = quoteResponseSchema.parse(await response.json())
   const {
     quote: { fiatAmount, quoteId, transferType },
     kyc: { kycRequired, kycSchemas },
@@ -102,25 +102,33 @@ export async function generateWidgetUrl() {
     `&quoteId=${quoteId}` +
     `&country=${config.country}`
   if (kycRequired) {
-    widgetUrl += `&kycSchema=${kycSchemas[0]}`
+    const kycSchema = kycSchemas[0].kycSchema
+    widgetUrl += `&kycSchema=${kycSchema}`
+    const kycAllowedValues = kycSchemas[0].allowedValues
+    if (kycAllowedValues) {
+      widgetUrl += `&kycAllowedValues=${JSON.stringify(kycAllowedValues)}`
+    }
   }
-  const fiatAccountType = Object.keys(fiatAccountJson)[0]
+  const fiatAccountType = Object.keys(fiatAccountJson)[0] as keyof typeof fiatAccountJson
   if (!fiatAccountType) {
     throw new Error('fiat account type not found in quote response')
   }
   widgetUrl += `&fiatAccountType=${fiatAccountType}`
   const fiatAccountSchema =
-    fiatAccountJson[fiatAccountType].fiatAccountSchemas[0].fiatAccountSchema
+    fiatAccountJson[fiatAccountType]?.fiatAccountSchemas[0]?.fiatAccountSchema
   if (!fiatAccountSchema) {
     throw new Error('fiat account schema not found in quote response')
   }
   widgetUrl += `&fiatAccountSchema=${fiatAccountSchema}`
   const userActionType =
-    fiatAccountJson[fiatAccountType].fiatAccountSchemas[0].userActionType
+    fiatAccountJson[fiatAccountType]?.fiatAccountSchemas[0].userActionType
   if (userActionType) {
     widgetUrl += `&userActionDetailsSchema=${userActionType}`
   }
-
+  const fiatAccountAllowedValues = fiatAccountJson[fiatAccountType]?.fiatAccountSchemas[0].allowedValues
+  if (fiatAccountAllowedValues) {
+    widgetUrl += `&fiatAccountAllowedValues=${JSON.stringify(fiatAccountAllowedValues)}`
+  }
   console.log(widgetUrl)
 }
 

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -31,5 +31,12 @@ describe('KYCInfoFieldSection', () => {
       const result = getDropdownValues({ allowedValues, choices, formatter })
       expect(result).toEqual(allowedValues)
     })
+    it('returns formatted values', () => {
+      const allowedValues: [string, ...string[]] = ['a', 'b']
+      const choices: [string, ...string[]] = ['A', 'B', 'C']
+      const formatter = (x: string) => x.toUpperCase()
+      const result = getDropdownValues({ allowedValues, choices, formatter })
+      expect(result).toEqual(['A', 'B'])
+    })
   })
 })

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -1,4 +1,5 @@
 import { getDropdownValues } from './KYCInfoFieldSection'
+import {idTypeReverseFormatter} from "./kycInfo/PersonalDataAndDocumentsDetailed";
 
 describe('KYCInfoFieldSection', () => {
   describe('getDropdownValues', () => {
@@ -6,36 +7,80 @@ describe('KYCInfoFieldSection', () => {
       const allowedValues: [string, ...string[]] = ['a', 'b']
       const choices = undefined
       const reverseFormatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
+      const result = getDropdownValues({
+        allowedValues,
+        choices,
+        reverseFormatter,
+      })
       expect(result).toEqual(allowedValues)
     })
     it('returns choices if allowedValues is undefined', () => {
       const allowedValues = undefined
       const choices: [string, ...string[]] = ['a', 'b']
       const reverseFormatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
+      const result = getDropdownValues({
+        allowedValues,
+        choices,
+        reverseFormatter,
+      })
       expect(result).toEqual(choices)
     })
     it('returns choices that are in allowedValues', () => {
       const allowedValues: [string, ...string[]] = ['a', 'b']
       const choices: [string, ...string[]] = ['a', 'b', 'c']
       const reverseFormatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
+      const result = getDropdownValues({
+        allowedValues,
+        choices,
+        reverseFormatter,
+      })
       expect(result).toEqual(allowedValues)
     })
     it('returns allowedValues if no choices are in allowedValues', () => {
       const allowedValues: [string, ...string[]] = ['a', 'b']
       const choices: [string, ...string[]] = ['c', 'd']
       const reverseFormatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
+      const result = getDropdownValues({
+        allowedValues,
+        choices,
+        reverseFormatter,
+      })
       expect(result).toEqual(allowedValues)
     })
-    it('returns formatted values', () => {
-      const allowedValues: [string, ...string[]] = ['a', 'b']
-      const choices: [string, ...string[]] = ['A', 'B', 'C']
-      const reverseFormatter = (x: string) => x.toUpperCase()
-      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
-      expect(result).toEqual(['A', 'B'])
+    it('returns human-readable values', () => {
+      const optionAid = 'a'
+      const optionAhumanReadable = 'Option A'
+      const optionBid = 'b'
+      const optionBhumanReadable = 'Option B'
+      const allowedValues: [string, ...string[]] = [optionAid, optionBid]
+      const choices: [string, ...string[]] = [
+        optionAhumanReadable,
+        optionBhumanReadable,
+        'Option C',
+      ]
+      const reverseFormatter = (optionId: string) =>
+        `Option ${optionId.toUpperCase()}`
+      const result = getDropdownValues({
+        allowedValues,
+        choices,
+        reverseFormatter,
+      })
+      expect(result).toEqual(['Option A', 'Option B'])
+    })
+    it('works for ID type field', () => {
+      const allowedValues: [string, ...string[]] = ['IDC', 'PAS']
+      const choices: [string, ...string[]] = [
+        'State-issued ID',
+        'Passport',
+        "Driver's License",
+      ]
+      const reverseFormatter = idTypeReverseFormatter
+      const result = getDropdownValues({
+        allowedValues,
+        choices,
+        reverseFormatter,
+      })
+      expect(result).toEqual(['State-issued ID', 'Passport'])
     })
   })
 })

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -1,5 +1,5 @@
 import { getDropdownValues } from './KYCInfoFieldSection'
-import {idTypeReverseFormatter} from "./kycInfo/PersonalDataAndDocumentsDetailed";
+import { idTypeReverseFormatter } from './kycInfo/PersonalDataAndDocumentsDetailed'
 
 describe('KYCInfoFieldSection', () => {
   describe('getDropdownValues', () => {

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -5,36 +5,36 @@ describe('KYCInfoFieldSection', () => {
     it('returns allowedValues if choices is undefined', () => {
       const allowedValues: [string, ...string[]] = ['a', 'b']
       const choices = undefined
-      const formatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, formatter })
+      const reverseFormatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
       expect(result).toEqual(allowedValues)
     })
     it('returns choices if allowedValues is undefined', () => {
       const allowedValues = undefined
       const choices: [string, ...string[]] = ['a', 'b']
-      const formatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, formatter })
+      const reverseFormatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
       expect(result).toEqual(choices)
     })
     it('returns choices that are in allowedValues', () => {
       const allowedValues: [string, ...string[]] = ['a', 'b']
       const choices: [string, ...string[]] = ['a', 'b', 'c']
-      const formatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, formatter })
+      const reverseFormatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
       expect(result).toEqual(allowedValues)
     })
     it('returns allowedValues if no choices are in allowedValues', () => {
       const allowedValues: [string, ...string[]] = ['a', 'b']
       const choices: [string, ...string[]] = ['c', 'd']
-      const formatter = undefined
-      const result = getDropdownValues({ allowedValues, choices, formatter })
+      const reverseFormatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
       expect(result).toEqual(allowedValues)
     })
     it('returns formatted values', () => {
       const allowedValues: [string, ...string[]] = ['a', 'b']
       const choices: [string, ...string[]] = ['A', 'B', 'C']
-      const formatter = (x: string) => x.toUpperCase()
-      const result = getDropdownValues({ allowedValues, choices, formatter })
+      const reverseFormatter = (x: string) => x.toUpperCase()
+      const result = getDropdownValues({ allowedValues, choices, reverseFormatter })
       expect(result).toEqual(['A', 'B'])
     })
   })

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -60,16 +60,20 @@ describe('KYCInfoFieldSection', () => {
       ]
       const reverseFormatter = (optionId: string) =>
         `Option ${optionId.toUpperCase()}`
-      expect(getDropdownValues({
-        allowedValues,
-        choices,
-        reverseFormatter,
-      })).toEqual(['Option A', 'Option B'])
-      expect(getDropdownValues({
-        allowedValues,
-        choices: undefined,
-        reverseFormatter,
-      })).toEqual(['Option A', 'Option B'])
+      expect(
+        getDropdownValues({
+          allowedValues,
+          choices,
+          reverseFormatter,
+        }),
+      ).toEqual(['Option A', 'Option B'])
+      expect(
+        getDropdownValues({
+          allowedValues,
+          choices: undefined,
+          reverseFormatter,
+        }),
+      ).toEqual(['Option A', 'Option B'])
     })
     it('works for ID type field', () => {
       const allowedValues: [string, ...string[]] = ['IDC', 'PAS']

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -1,5 +1,4 @@
-import {getDropdownValues} from "./KYCInfoFieldSection";
-
+import { getDropdownValues } from './KYCInfoFieldSection'
 
 describe('KYCInfoFieldSection', () => {
   describe('getDropdownValues', () => {

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -60,12 +60,16 @@ describe('KYCInfoFieldSection', () => {
       ]
       const reverseFormatter = (optionId: string) =>
         `Option ${optionId.toUpperCase()}`
-      const result = getDropdownValues({
+      expect(getDropdownValues({
         allowedValues,
         choices,
         reverseFormatter,
-      })
-      expect(result).toEqual(['Option A', 'Option B'])
+      })).toEqual(['Option A', 'Option B'])
+      expect(getDropdownValues({
+        allowedValues,
+        choices: undefined,
+        reverseFormatter,
+      })).toEqual(['Option A', 'Option B'])
     })
     it('works for ID type field', () => {
       const allowedValues: [string, ...string[]] = ['IDC', 'PAS']

--- a/src/components/KYCInfoFieldSection.test.tsx
+++ b/src/components/KYCInfoFieldSection.test.tsx
@@ -1,0 +1,35 @@
+import {getDropdownValues} from "./KYCInfoFieldSection";
+
+
+describe('KYCInfoFieldSection', () => {
+  describe('getDropdownValues', () => {
+    it('returns allowedValues if choices is undefined', () => {
+      const allowedValues: [string, ...string[]] = ['a', 'b']
+      const choices = undefined
+      const formatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, formatter })
+      expect(result).toEqual(allowedValues)
+    })
+    it('returns choices if allowedValues is undefined', () => {
+      const allowedValues = undefined
+      const choices: [string, ...string[]] = ['a', 'b']
+      const formatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, formatter })
+      expect(result).toEqual(choices)
+    })
+    it('returns choices that are in allowedValues', () => {
+      const allowedValues: [string, ...string[]] = ['a', 'b']
+      const choices: [string, ...string[]] = ['a', 'b', 'c']
+      const formatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, formatter })
+      expect(result).toEqual(allowedValues)
+    })
+    it('returns allowedValues if no choices are in allowedValues', () => {
+      const allowedValues: [string, ...string[]] = ['a', 'b']
+      const choices: [string, ...string[]] = ['c', 'd']
+      const formatter = undefined
+      const result = getDropdownValues({ allowedValues, choices, formatter })
+      expect(result).toEqual(allowedValues)
+    })
+  })
+})

--- a/src/components/KYCInfoFieldSection.tsx
+++ b/src/components/KYCInfoFieldSection.tsx
@@ -55,7 +55,7 @@ export function getDropdownValues({
   )
   if (!isNonemptyStringArray(output)) {
     // eslint-disable-next-line no-console
-    console.error(
+    console.warn(
       `No valid choices for given allowedValues ${allowedValues}. Just showing allowedValues directly`,
     )
     return formattedAllowedValues as [string, ...string[]]

--- a/src/components/KYCInfoFieldSection.tsx
+++ b/src/components/KYCInfoFieldSection.tsx
@@ -48,7 +48,9 @@ export function getDropdownValues({
   if (!choices) {
     return allowedValues
   }
-  const humanReadableAllowedValues = allowedValues.map(reverseFormatter ?? identity)
+  const humanReadableAllowedValues = allowedValues.map(
+    reverseFormatter ?? identity,
+  )
   const output = choices.filter((choice) =>
     humanReadableAllowedValues.includes(choice),
   )

--- a/src/components/KYCInfoFieldSection.tsx
+++ b/src/components/KYCInfoFieldSection.tsx
@@ -31,34 +31,33 @@ function identity<T>(x: T): T {
  * user submitted values from an unsupported region.
  * @param choices: a FiatConnect Widget-specific concept that allows us to provide a dropdown when the spec already has a limited
  * space of possible inputs for something like "identity card type"
- * @param formatter: a function that returns a user-friendly representation of some value
+ * @param reverseFormatter: a function that returns a user-friendly representation of some value
  */
 export function getDropdownValues({
   allowedValues,
   choices,
-  formatter,
+  reverseFormatter,
 }: {
   allowedValues: [string, ...string[]] | undefined
   choices: [string, ...string[]] | undefined
-  formatter?: (x: string) => string
+  reverseFormatter?: (x: string) => string
 }): [string, ...string[]] | undefined {
-  // TODO unit tests for this
   if (!allowedValues) {
     return choices
   }
   if (!choices) {
     return allowedValues
   }
-  const formattedAllowedValues = allowedValues.map(formatter ?? identity)
+  const humanReadableAllowedValues = allowedValues.map(reverseFormatter ?? identity)
   const output = choices.filter((choice) =>
-    formattedAllowedValues.includes(choice),
+    humanReadableAllowedValues.includes(choice),
   )
   if (!isNonemptyStringArray(output)) {
     // eslint-disable-next-line no-console
     console.warn(
       `No valid choices for given allowedValues ${allowedValues}. Just showing allowedValues directly`,
     )
-    return formattedAllowedValues as [string, ...string[]]
+    return humanReadableAllowedValues as [string, ...string[]]
   }
   return output
 }
@@ -187,7 +186,7 @@ function KYCInfoFieldSection({
             allowedValues={getDropdownValues({
               allowedValues: allowedValues?.[field],
               choices: fieldMetadata.choices,
-              formatter: fieldMetadata.formatter,
+              reverseFormatter: fieldMetadata.reverseFormatter,
             })}
           />
         )

--- a/src/components/KYCInfoFieldSection.tsx
+++ b/src/components/KYCInfoFieldSection.tsx
@@ -49,7 +49,9 @@ export function getDropdownValues({
     reverseFormatter ?? identity,
   )
   if (!choices) {
-    return isNonemptyStringArray(humanReadableAllowedValues) ? humanReadableAllowedValues : undefined
+    return isNonemptyStringArray(humanReadableAllowedValues)
+      ? humanReadableAllowedValues
+      : undefined
   }
   const output = choices.filter((choice) =>
     humanReadableAllowedValues.includes(choice),

--- a/src/components/KYCInfoFieldSection.tsx
+++ b/src/components/KYCInfoFieldSection.tsx
@@ -45,12 +45,12 @@ export function getDropdownValues({
   if (!allowedValues) {
     return choices
   }
-  if (!choices) {
-    return allowedValues
-  }
   const humanReadableAllowedValues = allowedValues.map(
     reverseFormatter ?? identity,
   )
+  if (!choices) {
+    return isNonemptyStringArray(humanReadableAllowedValues) ? humanReadableAllowedValues : undefined
+  }
   const output = choices.filter((choice) =>
     humanReadableAllowedValues.includes(choice),
   )

--- a/src/components/KYCInfoScreen.tsx
+++ b/src/components/KYCInfoScreen.tsx
@@ -124,6 +124,7 @@ export function KYCInfoScreen({
           setKycInfo={setKycInfoWrapper}
           setSubmitDisabled={setSubmitDisabled}
           kycSchemaMetadata={kycSchemaToMetadata[params.kycSchema]}
+          allowedValues={params.kycAllowedValues}
         />
       </div>
       <div id="KYCBottomSection">

--- a/src/components/PaymentInfoScreen.tsx
+++ b/src/components/PaymentInfoScreen.tsx
@@ -91,7 +91,7 @@ export function PaymentInfoScreen({
             fiatAccountDetails={fiatAccountDetails}
             setFiatAccountDetails={setFiatAccountDetailsWrapper}
             setSubmitDisabled={setSubmitDisabled}
-            allowedValues={params.allowedValues}
+            allowedValues={params.fiatAccountAllowedValues}
             fiatAccountType={FiatAccountType.BankAccount}
             fiatAccountSchemaMetadata={accountNumberSchemaMetadata}
           />
@@ -104,7 +104,7 @@ export function PaymentInfoScreen({
             fiatAccountDetails={fiatAccountDetails}
             setFiatAccountDetails={setFiatAccountDetailsWrapper}
             setSubmitDisabled={setSubmitDisabled}
-            allowedValues={params.allowedValues}
+            allowedValues={params.fiatAccountAllowedValues}
             fiatAccountType={FiatAccountType.MobileMoney}
             fiatAccountSchemaMetadata={mobileMoneySchemaMetadata}
           />

--- a/src/components/kycInfo/PersonalDataAndDocumentsDetailed.tsx
+++ b/src/components/kycInfo/PersonalDataAndDocumentsDetailed.tsx
@@ -3,7 +3,7 @@ import { IdentificationDocumentType } from '@fiatconnect/fiatconnect-types'
 import { Buffer } from 'buffer'
 
 enum IdTypeFriendlyName {
-  IDC = 'Statue-issued ID',
+  IDC = 'State-issued ID',
   PAS = 'Passport',
   DL = `Driver's License`,
 }
@@ -24,7 +24,7 @@ function idTypeFormatter(friendlyName: string): string {
   }
 }
 
-function idTypeReverseFormatter(idType: string | undefined): string {
+export function idTypeReverseFormatter(idType: string | undefined): string {
   switch (idType) {
     case IdentificationDocumentType.IDC: {
       return IdTypeFriendlyName.IDC

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -20,7 +20,7 @@ describe('schema', () => {
         country: ['NG'],
       }),
       kycAllowedValues: JSON.stringify({
-        country: ['NG', 'GH'],
+        isoCountryCode: ['NG', 'GH'],
       }),
     }
     it('accepts valid input', () => {

--- a/src/schema.test.ts
+++ b/src/schema.test.ts
@@ -15,6 +15,13 @@ describe('schema', () => {
       fiatAccountSchema: 'AccountNumber',
       userActionDetailsSchema: 'AccountNumberUserAction',
       country: 'NG',
+      fiatAccountAllowedValues: JSON.stringify({
+        institutionName: ['Access Bank', 'Covenant Microfinance Bank'],
+        country: ['NG'],
+      }),
+      kycAllowedValues: JSON.stringify({
+        country: ['NG', 'GH'],
+      }),
     }
     it('accepts valid input', () => {
       expect(queryParamsSchema.safeParse(validQueryParams).success).toEqual(
@@ -26,6 +33,20 @@ describe('schema', () => {
           ...validQueryParams,
           fiatAccountType: 'MobileMoney',
           fiatAccountSchema: 'MobileMoney',
+        }).success,
+      ).toEqual(true)
+
+      expect(
+        queryParamsSchema.safeParse({
+          ...validQueryParams,
+          kycAllowedValues: undefined,
+        }).success,
+      ).toEqual(true)
+
+      expect(
+        queryParamsSchema.safeParse({
+          ...validQueryParams,
+          fiatAccountAllowedValues: undefined,
         }).success,
       ).toEqual(true)
     })
@@ -52,6 +73,14 @@ describe('schema', () => {
         queryParamsSchema.safeParse({
           ...validQueryParams,
           quoteId: undefined,
+        }).success,
+      ).toEqual(false)
+
+      // invalid JSON for allowedValues
+      expect(
+        queryParamsSchema.safeParse({
+          ...validQueryParams,
+          fiatAccountAllowedValues: 'invalid-json',
         }).success,
       ).toEqual(false)
     })

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -24,7 +24,7 @@ const stringToJSONSchema = z
 const stringifiedNumberSchema = z.string().regex(/^(\d+|\d*\.\d+)$/)
 const allowedValuesSchema = stringToJSONSchema
   .pipe(z.record(z.array(z.string()).nonempty()))
-  .optional();
+  .optional()
 export const queryParamsSchema = z.object({
   providerId: z.nativeEnum(ProviderIds),
   apiKey: z.string().optional(),

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -22,6 +22,9 @@ const stringToJSONSchema = z
   })
 
 const stringifiedNumberSchema = z.string().regex(/^(\d+|\d*\.\d+)$/)
+const allowedValuesSchema = stringToJSONSchema
+  .pipe(z.record(z.array(z.string()).nonempty()))
+  .optional();
 export const queryParamsSchema = z.object({
   providerId: z.nativeEnum(ProviderIds),
   apiKey: z.string().optional(),
@@ -50,9 +53,8 @@ export const queryParamsSchema = z.object({
   userActionDetailsSchema: z
     .enum([TransferInUserActionDetails.AccountNumberUserAction])
     .optional(),
-  allowedValues: stringToJSONSchema
-    .pipe(z.record(z.array(z.string()).nonempty()))
-    .optional(),
+  fiatAccountAllowedValues: allowedValuesSchema,
+  kycAllowedValues: allowedValuesSchema,
   country: z.string(),
 })
 export type QueryParams = z.infer<typeof queryParamsSchema>


### PR DESCRIPTION
Tested a new helper function with a unit test, and the new high-level feature with a manual test. Adding `kycAllowedValues={"isoCountryCode":["NG"]}` as a query parameter for the widget, I was able to get the "country" dropdown in the screenshot below:
<img width="500" alt="Screenshot 2024-02-28 at 2 14 27 PM" src="https://github.com/fiatconnect/fiatconnect-widget/assets/7979215/84300dd3-b899-4560-ab05-a3aa8e06b823">

I also verified that alowedValues continues to work in the case where we already offer a dropdown of choices, such as with the `identificationDocumentType` field:
<img width="512" alt="Screenshot 2024-02-28 at 2 34 16 PM" src="https://github.com/fiatconnect/fiatconnect-widget/assets/7979215/4a2d9da6-1c87-4c25-ae72-1b63b1e93e37">

